### PR TITLE
Update InsertAt method

### DIFF
--- a/src/single.go
+++ b/src/single.go
@@ -83,17 +83,18 @@ func (l *LinkedList) InsertAt(pos int, value int) {
 	newNode := Node{}
 	newNode.value = value
 	// validate the position
-	if pos < 0 {
+  	// third case: the list is empty  
+	if pos < 0 || pos > l.len || l.len == 0 {
 		return
 	}
-	if pos == 0 {
+
+	if pos == 0 && l.len != 0 {
+		newNode.next = l.head
 		l.head = &newNode
 		l.len++
 		return
 	}
-	if pos > l.len {
-		return
-	}
+
 	n := l.GetAt(pos)
 	newNode.next = n
 	prevNode := l.GetAt(pos - 1)


### PR DESCRIPTION
### Fixing a bug

What do you want to do?
- Insert a new node at the single linked list with position 0 and value N.
- Do not allow creating a new node at position X if the list is empty

Actual result:
- When you want to insert a new node at position 0, on the single linked list structure, using InsertAt() method there exists a bug, because it replaces the header but does not refer to the previous header node.